### PR TITLE
Holobarriers para sec

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -142,6 +142,7 @@
 /obj/structure/closet/secure_closet/security/sec/PopulateContents()
 	..()
 	new /obj/item/storage/belt/security/full(src)
+	new /obj/item/holosign_creator/security (src)
 
 /obj/structure/closet/secure_closet/security/cargo
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega a los armarios de preparacion de los guardias un proyector de barreras (Holobarriers)

## ¿Por qué es bueno para el juego?
Es util para sec, asi tienen algo para bloquear una escena del crimen o similares, como la cinta policial en BoH.

## Changelog
:cl:
**add:** Holobarriers para sec
/:cl: