### PR TITLE
Energy Gun Y Laser Gun, Nuevo Tamaño Para Ambas

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -2,7 +2,7 @@
 	name = "energy gun"
 	desc = "A basic hybrid energy gun with two settings: disable and kill."
 	icon_state = "energy"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
 	modifystate = 1

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -3,7 +3,7 @@
 	desc = "A basic energy-based laser gun that fires concentrated beams of light which pass through glass and thin metal."
 	icon_state = "laser"
 	inhand_icon_state = "laser"
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1


### PR DESCRIPTION
### ¿Que hace este Pull Request?

Este Pull Request cambiara el tamaño actual de 2 armas de energia, y esas 2 armas a modificar seran las siguientes:

• Energy Gun.

• Laser Gun.

Se modifico lo siguiente:

• Tamaño de, Energy Gun
De Bulky, a, Normal.

• Tamaño de, Laser Gun.
De Bulky, a, Normal.

### ¿Porque este Pull Request es bueno?

Este Pull Request, segun mi opinion, puede ayudar al Equipo de Seguridad a agregar mas posibilidades de contener una amenaza. Con esto me refiero a, guardar una Energy Gun y/o Laser Gun en una mochila. Anteriormente, con el tamaño, "Bulky", no se podia, el cual complicaba el portar mas de una Energy Gun y/o Laser Gun.

### Opiniones

• Se hablo con Alejobort sobre este tema, el estuvo de acuerdo en el reducirle el tamaño actual a ambas armas, ya que era molesto el no poder guardar una Energy Gun o Laser Gun en una mochila.