### PR TITLE
Significante-Aumento-Para-Que-El-Blob-Tenga-Que-Ganar

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/autoplace_max_time = 3600 //six minutes, as long as should be needed
 	var/list/blobs_legit = list()
 	var/max_count = 0 //The biggest it got before death
-	var/blobwincount = 400
+	var/blobwincount = 1500
 	var/victory_in_progress = FALSE
 	var/rerolling = FALSE
 	var/announcement_size = 75


### PR DESCRIPTION
### ¿Que hace este Pull Request?

Lo que hace este Pull Request es aumentarle el "Blobwincount". a lo que se considera una Amenaza de Nivel 5, Blob.
BlobWinCount significa el numero total que el blob tiene que consumir para llegar a "Critical Mass", o, "Masa Critica".
Originalmente era de 450, pero sera subido a 1500.

### ¿Porque este Pull Request es bueno?

La estacion entera se pierde por esta Amenaza Nivel 5 por llegar a su, "Masa Critica" o "Critical Mass", y su, "meta", actual, no me parece muy justa, esto es porque se termina la ronda pocos segundos despues de ganar con un porcentaje de la estacion bajo. Aparte, alrededor de 450, aun se puede contener. Esto daria a la gente mas tiempo a evacuar si ven que la amenaza se sale de control. Por ultimo, cambia el significado de "Critical Mass", o, "Masa Critica", que ahora realmente si seria algo alarmante.

### Opiniones

Se hablo con Foxterosa sobre este tema, los numeros tomaron un tiempo, pero se llego a una decision por ahora.

**En Prueba**

Este Pull Request se ira analizando cuando se vea otra vez a la Amenaza de Nivel 5, esto significa que puede que no sea permanente.
La gente dira.


Changelog

:cl:
tweak: BlobWinCount-Aumentado-De-450-A-1500.
/:cl: